### PR TITLE
Lock haml version to ~>4.0

### DIFF
--- a/hamlbars.gemspec
+++ b/hamlbars.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/jamesotron/hamlbars'
   s.summary       = 'Extensions to Haml to allow creation of handlebars expressions.'
   s.description   = 'Hamlbars allows you to write handlebars templates using the familiar Haml syntax.'
-  s.add_dependency 'haml'
+  s.add_dependency 'haml', '~> 4.0'
   s.add_dependency 'sprockets', '>= 2.0'
   s.add_dependency 'tilt'
   s.add_dependency 'execjs', [">= 1.2"]


### PR DESCRIPTION
HAML 5.0.0 just released and appears to be incompatible with this gem.
Locking to 4.0 since that appears to be working properly.